### PR TITLE
Extend Btn Func with a loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aui-component-library",
-  "version": "1.0.21",
+  "version": "1.0.25",
   "description": "A react component library for Aui.",
   "files": [
     "dist/**/*"

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -19,7 +19,11 @@ export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   direction?: Direction;
   weight?: fontWeight;
   text?: React.ReactNode;
-  active?: Boolean;
+  active?: boolean;
+  hasIcon?: boolean;
+  loading?: boolean;
+  loader?: React.ReactNode;
+  color?: string;
 }
 
 // Forward the ref to the underlying button element
@@ -34,6 +38,10 @@ const Button = forwardRef<HTMLButtonElement, Props>(
       direction = "ltr",
       weight = "light",
       active = false,
+      hasIcon = false,
+      loading = false, // Default loading state
+      loader, // Custom loader if provided
+      color,
       ...props
     },
     ref
@@ -46,16 +54,29 @@ const Button = forwardRef<HTMLButtonElement, Props>(
     // Map fontWeight to actual pixel value
     const fontWeightClass = weight ? `font-weight-${weight}` : "";
 
+    // Map IconClass
+    const iconClass = icon || hasIcon ? "btn-with-icon" : "";
+
     return (
       <button
         ref={ref}
         data-variant={variant}
         data-active={active}
-        className={`btn dir-${direction} ${icon && "btn-with-icon"} aui-btn-${variant} ${fontWeightClass} ${className}`}
+        style={{ color, ...props.style }} // Inline style to apply the color
+        disabled={loading || props.disabled}
+        className={`btn dir-${direction} ${iconClass} aui-btn-${variant} ${fontWeightClass} ${className} ${
+          loading ? "loading" : ""
+        }`}
         {...props}
       >
-        {icon && <i className={`${getIconClass()}`} />}
-        {children || text}
+        {loading ? (
+          loader || <span className="default-loader" />
+        ) : (
+          <>
+            {icon && <i className={`${getIconClass()}`} />}
+            {children || text}
+          </>
+        )}
       </button>
     );
   }

--- a/src/components/Button/style.scss
+++ b/src/components/Button/style.scss
@@ -13,7 +13,7 @@
   width: inherit;
   border-radius: 4px;
   font-size: 14px;
-  line-height: normal;
+  line-height: 1;
   cursor: pointer;
   display: flex;
   justify-content: center;
@@ -107,6 +107,7 @@
   background-color: v.$blue-100;
   color: v.$white;
   border: none;
+  border-color: v.$white;
   @include hover-effect(v.$white);
 }
 
@@ -164,4 +165,26 @@
   border: none;
   color: #909090;
   background-color: transparent;
+}
+
+.default-loader {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border: 2px solid inherit;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.btn.loading {
+  pointer-events: none; // Prevent interactions while loading
 }

--- a/src/iconConstants.ts
+++ b/src/iconConstants.ts
@@ -1,4 +1,4 @@
-export type Icons = "dropdown-indicator" | "check" | "calculator" | "add" | "cancel" | "duplicate" | "edit" | "right-arrow" | 'warning' | 'print' | 'filter' | 'refresh' | 'left-arrow' | 'alert' | 'info' | 'download' | 'down-arrow';
+export type Icons = "calender" | "upload" | "setting" | "dropdown-indicator" | "check" | "calculator" | "add" | "cancel" | "duplicate" | "edit" | "right-arrow" | 'warning' | 'print' | 'filter' | 'refresh' | 'left-arrow' | 'alert' | 'info' | 'download' | 'down-arrow';
 
 export const iconMap: Record<Icons, string> = {
   refresh: "ri-refresh-line",
@@ -17,5 +17,8 @@ export const iconMap: Record<Icons, string> = {
   download: "ri-file-download-line",
   check: "ri-check-line",
   calculator:"ri-calculator-line",
-  "dropdown-indicator":"ri-arrow-down-s-line"
+  calender: "ri-calendar-2-line",
+  "dropdown-indicator":"ri-arrow-down-s-line",
+  setting: "ri-settings-3-fill",
+  upload: 'ri-upload-line'
 };


### PR DESCRIPTION
This Pull Request Introduces the following changes :-

- [x] Add Support For New Icons
- [x] Add A Loading State within Button
- [x] Introduce a new prop `color` for for Button Text.
- [x] Introduce a new prop `hasIcon` to manage padding where Icon has been passed within children in some scenarios